### PR TITLE
Multiple fixes, some related to issue #6

### DIFF
--- a/src/Query/Provider/DefaultOrm.php
+++ b/src/Query/Provider/DefaultOrm.php
@@ -7,9 +7,9 @@ use ZF\Apigility\Doctrine\Server\Paginator\Adapter\DoctrineOrmAdapter;
 use DoctrineModule\Persistence\ObjectManagerAwareInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Zend\Paginator\Adapter\AdapterInterface;
-use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
-use Zend\ServiceManger\ServiceLocatorInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\Rest\ResourceEvent;
 
 /**
  * Class FetchAllOrm
@@ -77,9 +77,9 @@ class DefaultOrm implements ObjectManagerAwareInterface, QueryProviderInterface,
      *
      * @return mixed This will return an ORM or ODM Query\Builder
      */
-    public function createQuery($event, $entityClass, $parameters)
+    public function createQuery(ResourceEvent $event, $entityClass, $parameters)
     {
-        $request = $this->getServiceManager()->get('Application')->getRequest()->getQuery()->toArray();
+        $request = $this->getServiceLocator()->getServiceLocator()->get('ControllerPluginManager')->get('params')->fromQuery();
 
         $queryBuilder = $this->getObjectManager()->createQueryBuilder();
         $queryBuilder->select('row')
@@ -87,7 +87,7 @@ class DefaultOrm implements ObjectManagerAwareInterface, QueryProviderInterface,
 
         if (isset($request['filter'])) {
             $metadata = $this->getObjectManager()->getMetadataFactory()->getAllMetadata();
-            $filterManager = $this->getServiceLocator()->get('ZfDoctrineQueryBuilderFilterManagerOrm');
+            $filterManager = $this->getServiceLocator()->getServiceLocator()->get('ZfDoctrineQueryBuilderFilterManagerOrm');
             $filterManager->filter(
                 $queryBuilder,
                 $metadata[0],
@@ -97,7 +97,7 @@ class DefaultOrm implements ObjectManagerAwareInterface, QueryProviderInterface,
 
         if (isset($request['order-by'])) {
             $metadata = $this->getObjectManager()->getMetadataFactory()->getAllMetadata();
-            $orderByManager = $this->getServiceLocator()->get('ZfDoctrineQueryBuilderOrderByManagerOrm');
+            $orderByManager = $this->getServiceLocator()->getServiceLocator()->get('ZfDoctrineQueryBuilderOrderByManagerOrm');
             $orderByManager->orderBy(
                 $queryBuilder,
                 $metadata[0],


### PR DESCRIPTION
Added `ResourceEvent` param type to createQuery to be compatible with `ZF\Apigility\Doctrine\Server\Query\Provider\QueryProviderInterface::createQuery`

Added double `getServiceLocator()` calls to get main ServiceManager at lines #82, #90 and #100.

Changed query param retrival to use controller plugin `params()`.

Signed-off-by: nesinervink <vluksys@takas.lt>