### PR TITLE
OrderBy\ORM\Field addOrderBy instead of orderBy

### DIFF
--- a/src/OrderBy/ORM/Field.php
+++ b/src/OrderBy/ORM/Field.php
@@ -20,6 +20,6 @@ class Field extends AbstractOrderBy
             throw new Exception('Invalid direction in orderby directive');
         }
 
-        $queryBuilder->orderBy($option['alias'] . '.' . $option['field'], $option['direction']);
+        $queryBuilder->addOrderBy($option['alias'] . '.' . $option['field'], $option['direction']);
     }
 }


### PR DESCRIPTION
Instead of using orderBy in ORM\Field of the queryBuilder it's better to use the addOrderBy of the queryBuilder. AddOrderBy won't override the Expr\OrderBy like the orderBy would in Doctrines QueryBuilder.